### PR TITLE
Format and clippy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,9 +4,16 @@ version = "0.1.0"
 authors = ["Jørgen Nordmoen <nordmoen90@gmail.com>"]
 
 [dependencies]
+clippy = { version = "0.0.80", optional = true }
 nalgebra = "0.8.2"
 num-traits = "0.1.34"
 
 [dev-dependencies]
 assert = "0.7.1"
 quickcheck = "0.3.1"
+
+[features]
+default = []
+dev = ["clippy"]
+
+

--- a/src/enu.rs
+++ b/src/enu.rs
@@ -1,8 +1,7 @@
 use ::Access;
 use ::ned::NED;
-use na::{Vector3, Norm, BaseFloat};
-use std::ops::{Add, AddAssign, Sub, SubAssign, Mul, MulAssign, Div, DivAssign,
-    Neg};
+use na::{BaseFloat, Norm, Vector3};
+use std::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
 /// East North Up vector
 ///
@@ -36,13 +35,13 @@ impl<N: Copy> ENU<N> {
     }
 }
 
-impl<N: Copy + Neg<Output=N>> From<NED<N>> for ENU<N> {
+impl<N: Copy + Neg<Output = N>> From<NED<N>> for ENU<N> {
     fn from(n: NED<N>) -> ENU<N> {
         ENU::new(n.east(), n.north(), -n.down())
     }
 }
 
-impl<N: Copy + Add<N, Output=N>> Add<ENU<N>> for ENU<N> {
+impl<N: Copy + Add<N, Output = N>> Add<ENU<N>> for ENU<N> {
     type Output = ENU<N>;
     fn add(self, right: ENU<N>) -> ENU<N> {
         ENU(self.0 + right.0)
@@ -55,7 +54,7 @@ impl<N: Copy + AddAssign<N>> AddAssign<ENU<N>> for ENU<N> {
     }
 }
 
-impl<N: Copy + Sub<N, Output=N>> Sub<ENU<N>> for ENU<N> {
+impl<N: Copy + Sub<N, Output = N>> Sub<ENU<N>> for ENU<N> {
     type Output = ENU<N>;
     fn sub(self, right: ENU<N>) -> ENU<N> {
         ENU(self.0 - right.0)
@@ -68,7 +67,7 @@ impl<N: Copy + SubAssign<N>> SubAssign<ENU<N>> for ENU<N> {
     }
 }
 
-impl<N: Copy + Mul<N, Output=N>> Mul<N> for ENU<N> {
+impl<N: Copy + Mul<N, Output = N>> Mul<N> for ENU<N> {
     type Output = ENU<N>;
     fn mul(self, right: N) -> ENU<N> {
         ENU(self.0 * right)
@@ -81,7 +80,7 @@ impl<N: Copy + MulAssign<N>> MulAssign<N> for ENU<N> {
     }
 }
 
-impl<N: Copy + Div<N, Output=N>> Div<N> for ENU<N> {
+impl<N: Copy + Div<N, Output = N>> Div<N> for ENU<N> {
     type Output = ENU<N>;
     fn div(self, right: N) -> Self {
         ENU(self.0 / right)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,7 @@
+#![cfg_attr(feature = "dev", allow(unstable_features))]
+#![cfg_attr(feature = "dev", feature(plugin))]
+#![cfg_attr(feature = "dev", plugin(clippy))]
+
 //! Easily work with global positions and vectors.
 //!
 //! This crate is intended to allow easy and safe interoperability between

--- a/src/ned.rs
+++ b/src/ned.rs
@@ -1,9 +1,8 @@
 use ::Access;
 use ::enu::ENU;
-use na::{Vector3, Norm, BaseFloat};
+use na::{BaseFloat, Norm, Vector3};
 use std::convert::From;
-use std::ops::{Add, AddAssign, Sub, SubAssign, Mul, MulAssign, Div, DivAssign,
-    Neg};
+use std::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
 /// North East Down vector
 ///
@@ -37,13 +36,13 @@ impl<N: Copy> NED<N> {
     }
 }
 
-impl<N: Copy + Neg<Output=N>> From<ENU<N>> for NED<N> {
+impl<N: Copy + Neg<Output = N>> From<ENU<N>> for NED<N> {
     fn from(e: ENU<N>) -> Self {
         NED::new(e.north(), e.east(), -e.up())
     }
 }
 
-impl<N: Copy + Add<N, Output=N>> Add<NED<N>> for NED<N> {
+impl<N: Copy + Add<N, Output = N>> Add<NED<N>> for NED<N> {
     type Output = NED<N>;
     fn add(self, right: NED<N>) -> NED<N> {
         NED(self.0 + right.0)
@@ -56,7 +55,7 @@ impl<N: Copy + AddAssign<N>> AddAssign<NED<N>> for NED<N> {
     }
 }
 
-impl<N: Copy + Sub<N, Output=N>> Sub<NED<N>> for NED<N> {
+impl<N: Copy + Sub<N, Output = N>> Sub<NED<N>> for NED<N> {
     type Output = NED<N>;
     fn sub(self, right: NED<N>) -> NED<N> {
         NED(self.0 - right.0)
@@ -69,7 +68,7 @@ impl<N: Copy + SubAssign<N>> SubAssign<NED<N>> for NED<N> {
     }
 }
 
-impl<N: Copy + Mul<N, Output=N>> Mul<N> for NED<N> {
+impl<N: Copy + Mul<N, Output = N>> Mul<N> for NED<N> {
     type Output = NED<N>;
     fn mul(self, right: N) -> NED<N> {
         NED(self.0 * right)
@@ -82,7 +81,7 @@ impl<N: Copy + MulAssign<N>> MulAssign<N> for NED<N> {
     }
 }
 
-impl<N: Copy + Div<N, Output=N>> Div<N> for NED<N> {
+impl<N: Copy + Div<N, Output = N>> Div<N> for NED<N> {
     type Output = NED<N>;
     fn div(self, right: N) -> NED<N> {
         NED(self.0 / right)
@@ -129,7 +128,7 @@ mod tests {
             assert_eq!(vec.east(), e);
             assert_eq!(vec.down(), d);
         }
-        
+
         fn from_enu(e: f32, n: f32, u: f32) -> () {
             let enu = ENU::new(e, n, u);
             let ned = NED::from(enu);


### PR DESCRIPTION
We format using rustfmt to get consistent formatting in the code base, trailing whitespace was eliminated.
One thing I didn't enjoy was truncating links because they were too long, it's easier to copy-paste them when they're on a single line. Maybe rustfmt could be patched to allow long comments.

I've added clippy as well, but it didn't give me any errors, it could be due to my outdated environment, please try `cargo build --features dev` to see clippy's output. Clippy is basically a 'Give me extra warnings' tool.
