### PR TITLE
Use `slice::iter` instead of `into_iter` to avoid future breakage

### DIFF
--- a/src/wgs84.rs
+++ b/src/wgs84.rs
@@ -293,7 +293,7 @@ mod tests {
         let stockholm: WGS84<f64> = WGS84::new(59.329444, 18.068611, 0.0);
         let stockholm_high: WGS84<f64> = WGS84::new(59.329444, 18.068611, 100.0);
 
-        for &(place, place_high) in [(oslo, oslo_high), (stockholm, stockholm_high)].into_iter() {
+        for &(place, place_high) in [(oslo, oslo_high), (stockholm, stockholm_high)].iter() {
             let distance =
                 ECEF::from(place_high).distance(&(ECEF::from(place) + ENU::new(0.0, 0.0, 100.0)));
             close(distance, 0.0, 0.00001);


### PR DESCRIPTION
`an_array.into_iter()` currently just works because of the autoref
feature, which then calls `<[T] as IntoIterator>::into_iter`. But
in the future, arrays will implement `IntoIterator`, too. In order
to avoid problems in the future, the call is replaced by `iter()`
which is shorter and more explicit.

A crater run showed that your crate is affected by a potential future 
change. See https://github.com/rust-lang/rust/pull/65819 for more information.