### PR TITLE
Add radians constructors for WGS84, rename functions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nav-types"
-version = "0.4.4"
+version = "0.5.0"
 authors = ["Jørgen Nordmoen <nordmoen90@gmail.com>"]
 description = "Easily work with global positions and vectors"
 edition = "2018"

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ extern crate nav_types;
 
 use nav_types::WGS84;
 
-let pos_a = WGS84::new(36.12, -86.67, 0.0);
-let pos_b = WGS84::new(33.94, -118.40, 0.0);
+let pos_a = WGS84::new_deg(36.12, -86.67, 0.0);
+let pos_b = WGS84::new_deg(33.94, -118.40, 0.0);
 
 println!("Distance between a and b: {:.2}m", a.distance(&b));
 ```
@@ -35,7 +35,7 @@ some coordinate system.
 ```rust
 use nav_types::{WGS84, ENU};
 
-let pos_a = WGS84::new(36.12, -86.67, 0.0);
+let pos_a = WGS84::new_deg(36.12, -86.67, 0.0);
 
 let vec = ENU::new(0.0, 0.0, 10.0);
 let pos_a_10m_up = pos_a + vec;

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ extern crate nav_types;
 
 use nav_types::WGS84;
 
-let pos_a = WGS84::new_deg(36.12, -86.67, 0.0);
-let pos_b = WGS84::new_deg(33.94, -118.40, 0.0);
+let pos_a = WGS84::from_degrees_and_meters(36.12, -86.67, 0.0);
+let pos_b = WGS84::from_degrees_and_meters(33.94, -118.40, 0.0);
 
 println!("Distance between a and b: {:.2}m", a.distance(&b));
 ```
@@ -35,7 +35,7 @@ some coordinate system.
 ```rust
 use nav_types::{WGS84, ENU};
 
-let pos_a = WGS84::new_deg(36.12, -86.67, 0.0);
+let pos_a = WGS84::from_degrees_and_meters(36.12, -86.67, 0.0);
 
 let vec = ENU::new(0.0, 0.0, 10.0);
 let pos_a_10m_up = pos_a + vec;

--- a/benches/lib.rs
+++ b/benches/lib.rs
@@ -8,24 +8,24 @@ mod ecef {
     use test::Bencher;
     #[bench]
     fn from_wgs84(b: &mut Bencher) {
-        let a = WGS84::new(36.12, -86.67, 12.3);
+        let a = WGS84::from_degrees_and_meters(36.12, -86.67, 12.3);
         b.iter(|| ECEF::from(a));
     }
     #[bench]
     fn from_nvector(b: &mut Bencher) {
-        let a = NVector::from(WGS84::new(36.12, -86.67, 12.3));
+        let a = NVector::from(WGS84::from_degrees_and_meters(36.12, -86.67, 12.3));
         b.iter(|| ECEF::from(a));
     }
     #[bench]
     fn difference(b: &mut Bencher) {
-        let pos_a = ECEF::from(WGS84::new(36.12, -86.67, 0.0));
-        let pos_b = ECEF::from(WGS84::new(33.94, -118.40, 0.0));
+        let pos_a = ECEF::from(WGS84::from_degrees_and_meters(36.12, -86.67, 0.0));
+        let pos_b = ECEF::from(WGS84::from_degrees_and_meters(33.94, -118.40, 0.0));
         b.iter(|| pos_b - pos_a);
     }
     #[bench]
     fn add_vector(b: &mut Bencher) {
-        let pos_a = ECEF::from(WGS84::new(36.12, -86.67, 0.0));
-        let pos_b = ECEF::from(WGS84::new(33.94, -118.40, 0.0));
+        let pos_a = ECEF::from(WGS84::from_degrees_and_meters(36.12, -86.67, 0.0));
+        let pos_b = ECEF::from(WGS84::from_degrees_and_meters(33.94, -118.40, 0.0));
 
         let vec = pos_b - pos_a;
         b.iter(|| pos_a + vec);
@@ -37,24 +37,24 @@ mod nvector {
     use test::Bencher;
     #[bench]
     fn from_wgs84(b: &mut Bencher) {
-        let a = WGS84::new(36.12, -86.67, 12.3);
+        let a = WGS84::from_degrees_and_meters(36.12, -86.67, 12.3);
         b.iter(|| NVector::from(a));
     }
     #[bench]
     fn from_ecef(b: &mut Bencher) {
-        let a = ECEF::from(WGS84::new(36.12, -86.67, 12.3));
+        let a = ECEF::from(WGS84::from_degrees_and_meters(36.12, -86.67, 12.3));
         b.iter(|| NVector::from(a));
     }
     #[bench]
     fn difference(b: &mut Bencher) {
-        let pos_a = NVector::from(WGS84::new(36.12, -86.67, 0.0));
-        let pos_b = NVector::from(WGS84::new(33.94, -118.40, 0.0));
+        let pos_a = NVector::from(WGS84::from_degrees_and_meters(36.12, -86.67, 0.0));
+        let pos_b = NVector::from(WGS84::from_degrees_and_meters(33.94, -118.40, 0.0));
         b.iter(|| pos_b - pos_a);
     }
     #[bench]
     fn add_vector(b: &mut Bencher) {
-        let pos_a = NVector::from(WGS84::new(36.12, -86.67, 0.0));
-        let pos_b = NVector::from(WGS84::new(33.94, -118.40, 0.0));
+        let pos_a = NVector::from(WGS84::from_degrees_and_meters(36.12, -86.67, 0.0));
+        let pos_b = NVector::from(WGS84::from_degrees_and_meters(33.94, -118.40, 0.0));
 
         let vec = pos_b - pos_a;
         b.iter(|| pos_a + vec);
@@ -68,16 +68,16 @@ mod wgs84 {
 
     #[bench]
     fn difference(b: &mut Bencher) {
-        let pos_a = WGS84::new(36.12, -86.67, 0.0);
-        let pos_b = WGS84::new(33.94, -118.40, 0.0);
+        let pos_a = WGS84::from_degrees_and_meters(36.12, -86.67, 0.0);
+        let pos_b = WGS84::from_degrees_and_meters(33.94, -118.40, 0.0);
 
         b.iter(|| pos_b - pos_a);
     }
 
     #[bench]
     fn add_vector(b: &mut Bencher) {
-        let pos_a = WGS84::new(36.12, -86.67, 0.0);
-        let pos_b = WGS84::new(33.94, -118.40, 0.0);
+        let pos_a = WGS84::from_degrees_and_meters(36.12, -86.67, 0.0);
+        let pos_b = WGS84::from_degrees_and_meters(33.94, -118.40, 0.0);
 
         let vec = pos_b - pos_a;
         b.iter(|| pos_a + vec);
@@ -85,14 +85,14 @@ mod wgs84 {
 
     #[bench]
     fn from_ecef(b: &mut Bencher) {
-        let ecef = ECEF::from(WGS84::new(36.12, -86.67, 0.0));
+        let ecef = ECEF::from(WGS84::from_degrees_and_meters(36.12, -86.67, 0.0));
 
         b.iter(|| WGS84::from(ecef));
     }
 
     #[bench]
     fn from_nvector(b: &mut Bencher) {
-        let nvec = NVector::from(WGS84::new(36.12, -86.67, 0.0));
+        let nvec = NVector::from(WGS84::from_degrees_and_meters(36.12, -86.67, 0.0));
 
         b.iter(|| WGS84::from(nvec));
     }

--- a/examples/example1.rs
+++ b/examples/example1.rs
@@ -6,8 +6,8 @@ fn main() {
     // First we define two positions in Latitude/Longitude,
     // this library only implement operations with WGS-84 ellipsoid
     // so we use that type
-    let pos_a = WGS84::new(36.12, -86.67, 0.0);
-    let pos_b = WGS84::new(33.94, -118.40, 0.0);
+    let pos_a = WGS84::new_deg(36.12, -86.67, 0.0);
+    let pos_b = WGS84::new_deg(33.94, -118.40, 0.0);
 
     // We could convert each of the positions to n-vectors with
     // `NVector::from(pos_a)`, but for the simple operations

--- a/examples/example1.rs
+++ b/examples/example1.rs
@@ -6,8 +6,8 @@ fn main() {
     // First we define two positions in Latitude/Longitude,
     // this library only implement operations with WGS-84 ellipsoid
     // so we use that type
-    let pos_a = WGS84::new_deg(36.12, -86.67, 0.0);
-    let pos_b = WGS84::new_deg(33.94, -118.40, 0.0);
+    let pos_a = WGS84::from_degrees_and_meters(36.12, -86.67, 0.0);
+    let pos_b = WGS84::from_degrees_and_meters(33.94, -118.40, 0.0);
 
     // We could convert each of the positions to n-vectors with
     // `NVector::from(pos_a)`, but for the simple operations

--- a/examples/example2.rs
+++ b/examples/example2.rs
@@ -4,7 +4,7 @@ use nav_types::{ENU, WGS84};
 
 fn main() {
     // We start with the position of our "vehicle"
-    let pos_a = WGS84::new(36.12, -86.67, 0.0);
+    let pos_a = WGS84::new_deg(36.12, -86.67, 0.0);
     // Next we have the vector from the "vehicle" to the desired object,
     // it is assumed that the vector is rotated into proper ENU or NED
     // format

--- a/examples/example2.rs
+++ b/examples/example2.rs
@@ -4,7 +4,7 @@ use nav_types::{ENU, WGS84};
 
 fn main() {
     // We start with the position of our "vehicle"
-    let pos_a = WGS84::new_deg(36.12, -86.67, 0.0);
+    let pos_a = WGS84::from_degrees_and_meters(36.12, -86.67, 0.0);
     // Next we have the vector from the "vehicle" to the desired object,
     // it is assumed that the vector is rotated into proper ENU or NED
     // format

--- a/examples/example4.rs
+++ b/examples/example4.rs
@@ -4,7 +4,7 @@ use nav_types::{ECEF, WGS84};
 
 fn main() {
     // We start with a position given in latitude, longitude and altitude
-    let position = WGS84::new_deg(36.12, -86.67, 0.0);
+    let position = WGS84::from_degrees_and_meters(36.12, -86.67, 0.0);
 
     // This can then easily be converted into ECEF by changing the type
     let ecef = ECEF::from(position);

--- a/examples/example4.rs
+++ b/examples/example4.rs
@@ -4,7 +4,7 @@ use nav_types::{ECEF, WGS84};
 
 fn main() {
     // We start with a position given in latitude, longitude and altitude
-    let position = WGS84::new(36.12, -86.67, 0.0);
+    let position = WGS84::new_deg(36.12, -86.67, 0.0);
 
     // This can then easily be converted into ECEF by changing the type
     let ecef = ECEF::from(position);

--- a/examples/example5.rs
+++ b/examples/example5.rs
@@ -9,8 +9,8 @@ fn main() {
     // First we define two positions in Latitude/Longitude,
     // this library only implement operations with WGS-84 ellipsoid
     // so we use that type
-    let pos_a = WGS84::new_deg(36.12, -86.67, 0.0);
-    let pos_b = WGS84::new_deg(33.94, -118.40, 0.0);
+    let pos_a = WGS84::from_degrees_and_meters(36.12, -86.67, 0.0);
+    let pos_b = WGS84::from_degrees_and_meters(33.94, -118.40, 0.0);
 
     // We then convert these positions into n-vectors:
     let n_a = NVector::from(pos_a);

--- a/examples/example5.rs
+++ b/examples/example5.rs
@@ -9,8 +9,8 @@ fn main() {
     // First we define two positions in Latitude/Longitude,
     // this library only implement operations with WGS-84 ellipsoid
     // so we use that type
-    let pos_a = WGS84::new(36.12, -86.67, 0.0);
-    let pos_b = WGS84::new(33.94, -118.40, 0.0);
+    let pos_a = WGS84::new_deg(36.12, -86.67, 0.0);
+    let pos_b = WGS84::new_deg(33.94, -118.40, 0.0);
 
     // We then convert these positions into n-vectors:
     let n_a = NVector::from(pos_a);

--- a/src/ecef.rs
+++ b/src/ecef.rs
@@ -42,15 +42,15 @@ impl<N: RealField> ECEF<N> {
     fn r_enu_from_ecef(self) -> Matrix3<N> {
         let wgs = WGS84::from(self);
         Matrix3::new(
-            -wgs.longitude_rad().sin(),
-            wgs.longitude_rad().cos(),
+            -wgs.longitude_radians().sin(),
+            wgs.longitude_radians().cos(),
             N::zero(),
-            -wgs.latitude_rad().sin() * wgs.longitude_rad().cos(),
-            -wgs.latitude_rad().sin() * wgs.longitude_rad().sin(),
-            wgs.latitude_rad().cos(),
-            wgs.latitude_rad().cos() * wgs.longitude_rad().cos(),
-            wgs.latitude_rad().cos() * wgs.longitude_rad().sin(),
-            wgs.latitude_rad().sin(),
+            -wgs.latitude_radians().sin() * wgs.longitude_radians().cos(),
+            -wgs.latitude_radians().sin() * wgs.longitude_radians().sin(),
+            wgs.latitude_radians().cos(),
+            wgs.latitude_radians().cos() * wgs.longitude_radians().cos(),
+            wgs.latitude_radians().cos() * wgs.longitude_radians().sin(),
+            wgs.latitude_radians().sin(),
         )
     }
 
@@ -191,15 +191,15 @@ impl<N: RealField> From<WGS84<N>> for ECEF<N> {
         let semi_major_axis = N::from_f64(SEMI_MAJOR_AXIS).unwrap();
         let ecc_part = N::from_f64(ECCENTRICITY_SQ).unwrap();
         let sin_part = N::from_f64(0.5).unwrap()
-            * (N::one() - (N::from_f64(2.0).unwrap() * wgs.latitude_rad()).cos());
+            * (N::one() - (N::from_f64(2.0).unwrap() * wgs.latitude_radians()).cos());
 
         let n = semi_major_axis / (N::one() - ecc_part * sin_part).sqrt();
         let altitude = wgs.altitude();
 
-        let x = (altitude + n) * wgs.latitude_rad().cos() * wgs.longitude_rad().cos();
-        let y = (altitude + n) * wgs.latitude_rad().cos() * wgs.longitude_rad().sin();
-        let z =
-            (altitude + n - N::from_f64(ECCENTRICITY_SQ).unwrap() * n) * wgs.latitude_rad().sin();
+        let x = (altitude + n) * wgs.latitude_radians().cos() * wgs.longitude_radians().cos();
+        let y = (altitude + n) * wgs.latitude_radians().cos() * wgs.longitude_radians().sin();
+        let z = (altitude + n - N::from_f64(ECCENTRICITY_SQ).unwrap() * n)
+            * wgs.latitude_radians().sin();
 
         ECEF::new(x, y, z)
     }
@@ -247,8 +247,8 @@ mod tests {
         fn from_wgs84(wgs: WGS84<f64>) -> () {
             let test = WGS84::from(ECEF::from(wgs));
 
-            close(wgs.latitude_rad(), test.latitude_rad(), 0.000001);
-            close(wgs.longitude_rad(), test.longitude_rad(), 0.000001);
+            close(wgs.latitude_radians(), test.latitude_radians(), 0.000001);
+            close(wgs.longitude_radians(), test.longitude_radians(), 0.000001);
             close(wgs.altitude(), test.altitude(), 0.000001);
         }
 

--- a/src/ecef.rs
+++ b/src/ecef.rs
@@ -42,15 +42,15 @@ impl<N: RealField> ECEF<N> {
     fn r_enu_from_ecef(self) -> Matrix3<N> {
         let wgs = WGS84::from(self);
         Matrix3::new(
-            -wgs.longitude().sin(),
-            wgs.longitude().cos(),
+            -wgs.longitude_rad().sin(),
+            wgs.longitude_rad().cos(),
             N::zero(),
-            -wgs.latitude().sin() * wgs.longitude().cos(),
-            -wgs.latitude().sin() * wgs.longitude().sin(),
-            wgs.latitude().cos(),
-            wgs.latitude().cos() * wgs.longitude().cos(),
-            wgs.latitude().cos() * wgs.longitude().sin(),
-            wgs.latitude().sin(),
+            -wgs.latitude_rad().sin() * wgs.longitude_rad().cos(),
+            -wgs.latitude_rad().sin() * wgs.longitude_rad().sin(),
+            wgs.latitude_rad().cos(),
+            wgs.latitude_rad().cos() * wgs.longitude_rad().cos(),
+            wgs.latitude_rad().cos() * wgs.longitude_rad().sin(),
+            wgs.latitude_rad().sin(),
         )
     }
 
@@ -191,14 +191,14 @@ impl<N: RealField> From<WGS84<N>> for ECEF<N> {
         let semi_major_axis = N::from_f64(SEMI_MAJOR_AXIS).unwrap();
         let ecc_part = N::from_f64(ECCENTRICITY_SQ).unwrap();
         let sin_part = N::from_f64(0.5).unwrap()
-            * (N::one() - (N::from_f64(2.0).unwrap() * wgs.latitude()).cos());
+            * (N::one() - (N::from_f64(2.0).unwrap() * wgs.latitude_rad()).cos());
 
         let n = semi_major_axis / (N::one() - ecc_part * sin_part).sqrt();
         let altitude = wgs.altitude();
 
-        let x = (altitude + n) * wgs.latitude().cos() * wgs.longitude().cos();
-        let y = (altitude + n) * wgs.latitude().cos() * wgs.longitude().sin();
-        let z = (altitude + n - N::from_f64(ECCENTRICITY_SQ).unwrap() * n) * wgs.latitude().sin();
+        let x = (altitude + n) * wgs.latitude_rad().cos() * wgs.longitude_rad().cos();
+        let y = (altitude + n) * wgs.latitude_rad().cos() * wgs.longitude_rad().sin();
+        let z = (altitude + n - N::from_f64(ECCENTRICITY_SQ).unwrap() * n) * wgs.latitude_rad().sin();
 
         ECEF::new(x, y, z)
     }
@@ -246,8 +246,8 @@ mod tests {
         fn from_wgs84(wgs: WGS84<f64>) -> () {
             let test = WGS84::from(ECEF::from(wgs));
 
-            close(wgs.latitude(), test.latitude(), 0.000001);
-            close(wgs.longitude(), test.longitude(), 0.000001);
+            close(wgs.latitude_rad(), test.latitude_rad(), 0.000001);
+            close(wgs.longitude_rad(), test.longitude_rad(), 0.000001);
             close(wgs.altitude(), test.altitude(), 0.000001);
         }
 

--- a/src/ecef.rs
+++ b/src/ecef.rs
@@ -198,7 +198,8 @@ impl<N: RealField> From<WGS84<N>> for ECEF<N> {
 
         let x = (altitude + n) * wgs.latitude_rad().cos() * wgs.longitude_rad().cos();
         let y = (altitude + n) * wgs.latitude_rad().cos() * wgs.longitude_rad().sin();
-        let z = (altitude + n - N::from_f64(ECCENTRICITY_SQ).unwrap() * n) * wgs.latitude_rad().sin();
+        let z =
+            (altitude + n - N::from_f64(ECCENTRICITY_SQ).unwrap() * n) * wgs.latitude_rad().sin();
 
         ECEF::new(x, y, z)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,8 +14,8 @@
 //! use nav_types::{ECEF, WGS84, ENU, NED};
 //!
 //! // Define positions using latitude and longitude on the WGS84 ellipsoid
-//! let oslo = WGS84::new_deg(59.95, 10.75, 0.0);
-//! let stockholm = WGS84::new_deg(59.329444, 18.068611, 0.0);
+//! let oslo = WGS84::from_degrees_and_meters(59.95, 10.75, 0.0);
+//! let stockholm = WGS84::from_degrees_and_meters(59.329444, 18.068611, 0.0);
 //!
 //! println!("Great circle distance between Oslo and Stockholm: {:?}",
 //!     oslo.distance(&stockholm));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,8 +14,8 @@
 //! use nav_types::{ECEF, WGS84, ENU, NED};
 //!
 //! // Define positions using latitude and longitude on the WGS84 ellipsoid
-//! let oslo = WGS84::new(59.95, 10.75, 0.0);
-//! let stockholm = WGS84::new(59.329444, 18.068611, 0.0);
+//! let oslo = WGS84::new_deg(59.95, 10.75, 0.0);
+//! let stockholm = WGS84::new_deg(59.329444, 18.068611, 0.0);
 //!
 //! println!("Great circle distance between Oslo and Stockholm: {:?}",
 //!     oslo.distance(&stockholm));

--- a/src/nvector.rs
+++ b/src/nvector.rs
@@ -41,9 +41,9 @@ impl<N: RealField> From<WGS84<N>> for NVector<N> {
         // defined. See: Table 2 in Gade(2010).
         // NOTE: This is consistent with the ECEF implementation in this crate
         let vec = Vector3::new(
-            f.longitude().cos() * f.latitude().cos(),
-            f.longitude().sin() * f.latitude().cos(),
-            f.latitude().sin(),
+            f.longitude_rad().cos() * f.latitude_rad().cos(),
+            f.longitude_rad().sin() * f.latitude_rad().cos(),
+            f.latitude_rad().sin(),
         );
         NVector::new(vec, f.altitude())
     }
@@ -97,8 +97,8 @@ mod tests {
         fn from_wgs84(wgs: WGS84<f64>) -> () {
             let test = WGS84::from(NVector::from(wgs));
 
-            close(wgs.latitude(), test.latitude(), 0.000001);
-            close(wgs.longitude(), test.longitude(), 0.000001);
+            close(wgs.latitude_rad(), test.latitude_rad(), 0.000001);
+            close(wgs.longitude_rad(), test.longitude_rad(), 0.000001);
             close(wgs.altitude(), test.altitude(), 0.000001);
         }
 

--- a/src/nvector.rs
+++ b/src/nvector.rs
@@ -41,9 +41,9 @@ impl<N: RealField> From<WGS84<N>> for NVector<N> {
         // defined. See: Table 2 in Gade(2010).
         // NOTE: This is consistent with the ECEF implementation in this crate
         let vec = Vector3::new(
-            f.longitude_rad().cos() * f.latitude_rad().cos(),
-            f.longitude_rad().sin() * f.latitude_rad().cos(),
-            f.latitude_rad().sin(),
+            f.longitude_radians().cos() * f.latitude_radians().cos(),
+            f.longitude_radians().sin() * f.latitude_radians().cos(),
+            f.latitude_radians().sin(),
         );
         NVector::new(vec, f.altitude())
     }
@@ -97,8 +97,8 @@ mod tests {
         fn from_wgs84(wgs: WGS84<f64>) -> () {
             let test = WGS84::from(NVector::from(wgs));
 
-            close(wgs.latitude_rad(), test.latitude_rad(), 0.000001);
-            close(wgs.longitude_rad(), test.longitude_rad(), 0.000001);
+            close(wgs.latitude_radians(), test.latitude_radians(), 0.000001);
+            close(wgs.longitude_radians(), test.longitude_radians(), 0.000001);
             close(wgs.altitude(), test.altitude(), 0.000001);
         }
 

--- a/src/wgs84.rs
+++ b/src/wgs84.rs
@@ -87,11 +87,11 @@ where
     /// WGS84 ellipsoid.
     pub fn new_rad(latitude: N, longitude: N, altitude: N) -> WGS84<N> {
         assert!(
-            latitude.abs() <= N::from_f64(f64::FRAC_PI_2).unwrap(),
+            latitude.abs() <= N::from_f64(std::f64::consts::FRAC_PI_2).unwrap(),
             "Latitude must be in the range [-π/2, π/2]"
         );
         assert!(
-            longitude.abs() <= N::from_f64(f64::PI).unwrap(),
+            longitude.abs() <= N::from_f64(std::f64::consts::PI).unwrap(),
             "Longitude must be in the range [-π, π]"
         );
         WGS84 {
@@ -108,8 +108,8 @@ where
     /// - `longitude` in radians
     /// - `altitude` in meters
     pub fn try_new_rad(latitude: N, longitude: N, altitude: N) -> Option<WGS84<N>> {
-        if latitude.abs() <= N::from_f64(f64::FRAC_PI_2).unwrap()
-            && longitude.abs() <= N::from_f64(f64::PI).unwrap()
+        if latitude.abs() <= N::from_f64(std::f64::consts::FRAC_PI_2).unwrap()
+            && longitude.abs() <= N::from_f64(std::f64::consts::PI).unwrap()
         {
             Some(WGS84::new_rad(latitude, longitude, altitude))
         } else {

--- a/src/wgs84.rs
+++ b/src/wgs84.rs
@@ -43,7 +43,7 @@ where
     /// # Panics
     /// This will panic if `latitude` or `longitude` are not defined on the
     /// WGS84 ellipsoid.
-    pub fn new_deg(latitude: N, longitude: N, altitude: N) -> WGS84<N> {
+    pub fn from_degrees_and_meters(latitude: N, longitude: N, altitude: N) -> WGS84<N> {
         assert!(
             latitude.abs() <= N::from_f64(90.0).unwrap(),
             "Latitude must be in the range [-90, 90]"
@@ -65,11 +65,13 @@ where
     /// - `latitude` in degrees
     /// - `longitude` in degrees
     /// - `altitude` in meters
-    pub fn try_new_deg(latitude: N, longitude: N, altitude: N) -> Option<WGS84<N>> {
+    pub fn try_from_degrees_and_meters(latitude: N, longitude: N, altitude: N) -> Option<WGS84<N>> {
         if latitude.abs() <= N::from_f64(90.0).unwrap()
             && longitude.abs() <= N::from_f64(180.0).unwrap()
         {
-            Some(WGS84::new_deg(latitude, longitude, altitude))
+            Some(WGS84::from_degrees_and_meters(
+                latitude, longitude, altitude,
+            ))
         } else {
             None
         }
@@ -85,7 +87,7 @@ where
     /// # Panics
     /// This will panic if `latitude` or `longitude` are not defined on the
     /// WGS84 ellipsoid.
-    pub fn new_rad(latitude: N, longitude: N, altitude: N) -> WGS84<N> {
+    pub fn from_radians_and_meters(latitude: N, longitude: N, altitude: N) -> WGS84<N> {
         assert!(
             latitude.abs() <= N::from_f64(std::f64::consts::FRAC_PI_2).unwrap(),
             "Latitude must be in the range [-π/2, π/2]"
@@ -107,7 +109,7 @@ where
     /// - `latitude` in radians
     /// - `longitude` in radians
     /// - `altitude` in meters
-    pub fn try_new_rad(latitude: N, longitude: N, altitude: N) -> Option<WGS84<N>> {
+    pub fn try_from_radians_and_meters(latitude: N, longitude: N, altitude: N) -> Option<WGS84<N>> {
         if latitude.abs() <= N::from_f64(std::f64::consts::FRAC_PI_2).unwrap()
             && longitude.abs() <= N::from_f64(std::f64::consts::PI).unwrap()
         {
@@ -122,12 +124,12 @@ where
     }
 
     /// Get latitude of position, in degrees
-    pub fn latitude_deg(&self) -> N {
+    pub fn latitude_degrees(&self) -> N {
         N::from_f64(f64::from(self.lat).to_degrees()).unwrap()
     }
 
     /// Get longitude of position, in degrees
-    pub fn longitude_deg(&self) -> N {
+    pub fn longitude_degrees(&self) -> N {
         N::from_f64(f64::from(self.lon).to_degrees()).unwrap()
     }
 
@@ -141,19 +143,19 @@ where
     /// ```rust
     /// use nav_types::WGS84;
     ///
-    /// let oslo = WGS84::new_deg(59.95, 10.75, 0.0);
-    /// let stockholm = WGS84::new_deg(59.329444, 18.068611, 0.0);
+    /// let oslo = WGS84::from_degrees_and_meters(59.95, 10.75, 0.0);
+    /// let stockholm = WGS84::from_degrees_and_meters(59.329444, 18.068611, 0.0);
     ///
     /// println!("Great circle distance between Oslo and Stockholm: {:?}",
     ///     oslo.distance(&stockholm));
     /// ```
     pub fn distance(&self, other: &WGS84<N>) -> N {
-        let delta_lat = other.latitude_rad() - self.latitude_rad();
-        let delta_lon = other.longitude_rad() - self.longitude_rad();
+        let delta_lat = other.latitude_radians() - self.latitude_radians();
+        let delta_lon = other.longitude_radians() - self.longitude_radians();
 
         let a = (delta_lat / N::from_f64(2.0).unwrap()).sin().powi(2)
-            + self.latitude_rad().cos()
-                * other.latitude_rad().cos()
+            + self.latitude_radians().cos()
+                * other.latitude_radians().cos()
                 * (delta_lon / N::from_f64(2.0).unwrap()).sin().powi(2);
         let c = N::from_f64(2.0).unwrap() * a.sqrt().asin();
 
@@ -162,16 +164,16 @@ where
 }
 
 impl<N: Copy> WGS84<N> {
-    /// Get altitude of position
+    /// Get altitude of position, in meters
     pub fn altitude(&self) -> N {
         self.alt
     }
     /// Get latitude of position, in radians
-    pub fn latitude_rad(&self) -> N {
+    pub fn latitude_radians(&self) -> N {
         self.lat
     }
     /// Get longitude of position, in radians
-    pub fn longitude_rad(&self) -> N {
+    pub fn longitude_radians(&self) -> N {
         self.lon
     }
 }
@@ -260,7 +262,7 @@ impl Arbitrary for WGS84<f64> {
         // below might still cause problems
         let alt = g.gen_range(-6300000.0, 10000000.0);
 
-        WGS84::new_deg(lat, lon, alt)
+        WGS84::from_degrees_and_meters(lat, lon, alt)
     }
 }
 
@@ -284,7 +286,7 @@ mod tests {
             // If either latitude or longitude is outside acceptable range
             // the test must fail
             TestResult::must_fail(move || {
-                WGS84::new_deg(latitude, longitude, altitude);
+                WGS84::from_degrees_and_meters(latitude, longitude, altitude);
             })
         }
     }
@@ -298,21 +300,21 @@ mod tests {
     fn dateline() {
         // This test ensures that when moving west from the dateline
         // the longitude resets to 180
-        let a = WGS84::new_deg(20.0, 180.0, 0.0);
+        let a = WGS84::from_degrees_and_meters(20.0, 180.0, 0.0);
         let vec = ENU::new(-10.0, 0.0, 0.0);
 
         let ans = a + vec;
         // NOTE: Precision here is rather arbitrary and depends on the
         // length of the vector used and so on, we are mostly interested
         // in seeing that the longitude is reset to positive
-        close(ans.longitude_deg(), 180.0, 0.001);
-        close(ans.latitude_deg(), 20.0, 0.001);
+        close(ans.longitude_degrees(), 180.0, 0.001);
+        close(ans.latitude_degrees(), 20.0, 0.001);
     }
 
     #[test]
     fn conversion_inversion_ecef() {
-        let oslo: WGS84<f64> = WGS84::new_deg(59.95, 10.75, 0.0);
-        let stockholm: WGS84<f64> = WGS84::new_deg(59.329444, 18.068611, 0.0);
+        let oslo: WGS84<f64> = WGS84::from_degrees_and_meters(59.95, 10.75, 0.0);
+        let stockholm: WGS84<f64> = WGS84::from_degrees_and_meters(59.329444, 18.068611, 0.0);
 
         for &place in [oslo, stockholm].iter() {
             let distance = place.distance(&WGS84::from(ECEF::from(place)));
@@ -322,7 +324,7 @@ mod tests {
 
     #[test]
     fn conversion_ecef() {
-        let oslo_wgs84: WGS84<f64> = WGS84::new_deg(59.95, 10.75, 0.0);
+        let oslo_wgs84: WGS84<f64> = WGS84::from_degrees_and_meters(59.95, 10.75, 0.0);
         let oslo_ecef: ECEF<f64> = ECEF::new(3145735.0, 597236.0, 5497690.0);
 
         for &(place_wgs84, place_ecef) in [(oslo_wgs84, oslo_ecef)].iter() {
@@ -333,11 +335,12 @@ mod tests {
 
     #[test]
     fn add_enu() {
-        let oslo: WGS84<f64> = WGS84::new_deg(59.95, 10.75, 0.0);
-        let oslo_high: WGS84<f64> = WGS84::new_deg(59.95, 10.75, 100.0);
+        let oslo: WGS84<f64> = WGS84::from_degrees_and_meters(59.95, 10.75, 0.0);
+        let oslo_high: WGS84<f64> = WGS84::from_degrees_and_meters(59.95, 10.75, 100.0);
 
-        let stockholm: WGS84<f64> = WGS84::new_deg(59.329444, 18.068611, 0.0);
-        let stockholm_high: WGS84<f64> = WGS84::new_deg(59.329444, 18.068611, 100.0);
+        let stockholm: WGS84<f64> = WGS84::from_degrees_and_meters(59.329444, 18.068611, 0.0);
+        let stockholm_high: WGS84<f64> =
+            WGS84::from_degrees_and_meters(59.329444, 18.068611, 100.0);
 
         for &(place, place_high) in [(oslo, oslo_high), (stockholm, stockholm_high)].iter() {
             let distance =

--- a/src/wgs84.rs
+++ b/src/wgs84.rs
@@ -75,6 +75,48 @@ where
         }
     }
 
+    /// Create a new WGS84 position
+    ///
+    /// # Arguments
+    /// - `latitude` in radians
+    /// - `longitude` in radians
+    /// - `altitude` in meters
+    ///
+    /// # Panics
+    /// This will panic if `latitude` or `longitude` are not defined on the
+    /// WGS84 ellipsoid.
+    pub fn new_rad(latitude: N, longitude: N, altitude: N) -> WGS84<N> {
+        assert!(
+            latitude.abs() <= N::from_f64(f64::FRAC_PI_2).unwrap(),
+            "Latitude must be in the range [-π/2, π/2]"
+        );
+        assert!(
+            longitude.abs() <= N::from_f64(f64::PI).unwrap(),
+            "Longitude must be in the range [-π, π]"
+        );
+        WGS84 {
+            lat: latitude,
+            lon: longitude,
+            alt: altitude,
+        }
+    }
+
+    /// Try to create a new WGS84 position
+    ///
+    /// # Arguments
+    /// - `latitude` in radians
+    /// - `longitude` in radians
+    /// - `altitude` in meters
+    pub fn try_new_rad(latitude: N, longitude: N, altitude: N) -> Option<WGS84<N>> {
+        if latitude.abs() <= N::from_f64(f64::FRAC_PI_2).unwrap()
+            && longitude.abs() <= N::from_f64(f64::PI).unwrap()
+        {
+            Some(WGS84::new_rad(latitude, longitude, altitude))
+        } else {
+            None
+        }
+    }
+
     /// Get latitude of position, in degrees
     pub fn latitude_degrees(&self) -> N {
         N::from_f64(f64::from(self.lat).to_degrees()).unwrap()

--- a/src/wgs84.rs
+++ b/src/wgs84.rs
@@ -43,7 +43,7 @@ where
     /// # Panics
     /// This will panic if `latitude` or `longitude` are not defined on the
     /// WGS84 ellipsoid.
-    pub fn new(latitude: N, longitude: N, altitude: N) -> WGS84<N> {
+    pub fn new_deg(latitude: N, longitude: N, altitude: N) -> WGS84<N> {
         assert!(
             latitude.abs() <= N::from_f64(90.0).unwrap(),
             "Latitude must be in the range [-90, 90]"
@@ -65,11 +65,11 @@ where
     /// - `latitude` in degrees
     /// - `longitude` in degrees
     /// - `altitude` in meters
-    pub fn try_new(latitude: N, longitude: N, altitude: N) -> Option<WGS84<N>> {
+    pub fn try_new_deg(latitude: N, longitude: N, altitude: N) -> Option<WGS84<N>> {
         if latitude.abs() <= N::from_f64(90.0).unwrap()
             && longitude.abs() <= N::from_f64(180.0).unwrap()
         {
-            Some(WGS84::new(latitude, longitude, altitude))
+            Some(WGS84::new_deg(latitude, longitude, altitude))
         } else {
             None
         }
@@ -111,19 +111,23 @@ where
         if latitude.abs() <= N::from_f64(std::f64::consts::FRAC_PI_2).unwrap()
             && longitude.abs() <= N::from_f64(std::f64::consts::PI).unwrap()
         {
-            Some(WGS84::new_rad(latitude, longitude, altitude))
+            Some(WGS84 {
+                lat: latitude,
+                lon: longitude,
+                alt: altitude,
+            })
         } else {
             None
         }
     }
 
     /// Get latitude of position, in degrees
-    pub fn latitude_degrees(&self) -> N {
+    pub fn latitude_deg(&self) -> N {
         N::from_f64(f64::from(self.lat).to_degrees()).unwrap()
     }
 
     /// Get longitude of position, in degrees
-    pub fn longitude_degrees(&self) -> N {
+    pub fn longitude_deg(&self) -> N {
         N::from_f64(f64::from(self.lon).to_degrees()).unwrap()
     }
 
@@ -137,19 +141,19 @@ where
     /// ```rust
     /// use nav_types::WGS84;
     ///
-    /// let oslo = WGS84::new(59.95, 10.75, 0.0);
-    /// let stockholm = WGS84::new(59.329444, 18.068611, 0.0);
+    /// let oslo = WGS84::new_deg(59.95, 10.75, 0.0);
+    /// let stockholm = WGS84::new_deg(59.329444, 18.068611, 0.0);
     ///
     /// println!("Great circle distance between Oslo and Stockholm: {:?}",
     ///     oslo.distance(&stockholm));
     /// ```
     pub fn distance(&self, other: &WGS84<N>) -> N {
-        let delta_lat = other.latitude() - self.latitude();
-        let delta_lon = other.longitude() - self.longitude();
+        let delta_lat = other.latitude_rad() - self.latitude_rad();
+        let delta_lon = other.longitude_rad() - self.longitude_rad();
 
         let a = (delta_lat / N::from_f64(2.0).unwrap()).sin().powi(2)
-            + self.latitude().cos()
-                * other.latitude().cos()
+            + self.latitude_rad().cos()
+                * other.latitude_rad().cos()
                 * (delta_lon / N::from_f64(2.0).unwrap()).sin().powi(2);
         let c = N::from_f64(2.0).unwrap() * a.sqrt().asin();
 
@@ -162,12 +166,12 @@ impl<N: Copy> WGS84<N> {
     pub fn altitude(&self) -> N {
         self.alt
     }
-    /// Get latitude in radians
-    pub fn latitude(&self) -> N {
+    /// Get latitude of position, in radians
+    pub fn latitude_rad(&self) -> N {
         self.lat
     }
-    /// Get longitude in radians
-    pub fn longitude(&self) -> N {
+    /// Get longitude of position, in radians
+    pub fn longitude_rad(&self) -> N {
         self.lon
     }
 }
@@ -256,7 +260,7 @@ impl Arbitrary for WGS84<f64> {
         // below might still cause problems
         let alt = g.gen_range(-6300000.0, 10000000.0);
 
-        WGS84::new(lat, lon, alt)
+        WGS84::new_deg(lat, lon, alt)
     }
 }
 
@@ -280,7 +284,7 @@ mod tests {
             // If either latitude or longitude is outside acceptable range
             // the test must fail
             TestResult::must_fail(move || {
-                WGS84::new(latitude, longitude, altitude);
+                WGS84::new_deg(latitude, longitude, altitude);
             })
         }
     }
@@ -294,21 +298,21 @@ mod tests {
     fn dateline() {
         // This test ensures that when moving west from the dateline
         // the longitude resets to 180
-        let a = WGS84::new(20.0, 180.0, 0.0);
+        let a = WGS84::new_deg(20.0, 180.0, 0.0);
         let vec = ENU::new(-10.0, 0.0, 0.0);
 
         let ans = a + vec;
         // NOTE: Precision here is rather arbitrary and depends on the
         // length of the vector used and so on, we are mostly interested
         // in seeing that the longitude is reset to positive
-        close(ans.longitude_degrees(), 180.0, 0.001);
-        close(ans.latitude_degrees(), 20.0, 0.001);
+        close(ans.longitude_deg(), 180.0, 0.001);
+        close(ans.latitude_deg(), 20.0, 0.001);
     }
 
     #[test]
     fn conversion_inversion_ecef() {
-        let oslo: WGS84<f64> = WGS84::new(59.95, 10.75, 0.0);
-        let stockholm: WGS84<f64> = WGS84::new(59.329444, 18.068611, 0.0);
+        let oslo: WGS84<f64> = WGS84::new_deg(59.95, 10.75, 0.0);
+        let stockholm: WGS84<f64> = WGS84::new_deg(59.329444, 18.068611, 0.0);
 
         for &place in [oslo, stockholm].iter() {
             let distance = place.distance(&WGS84::from(ECEF::from(place)));
@@ -318,7 +322,7 @@ mod tests {
 
     #[test]
     fn conversion_ecef() {
-        let oslo_wgs84: WGS84<f64> = WGS84::new(59.95, 10.75, 0.0);
+        let oslo_wgs84: WGS84<f64> = WGS84::new_deg(59.95, 10.75, 0.0);
         let oslo_ecef: ECEF<f64> = ECEF::new(3145735.0, 597236.0, 5497690.0);
 
         for &(place_wgs84, place_ecef) in [(oslo_wgs84, oslo_ecef)].iter() {
@@ -329,11 +333,11 @@ mod tests {
 
     #[test]
     fn add_enu() {
-        let oslo: WGS84<f64> = WGS84::new(59.95, 10.75, 0.0);
-        let oslo_high: WGS84<f64> = WGS84::new(59.95, 10.75, 100.0);
+        let oslo: WGS84<f64> = WGS84::new_deg(59.95, 10.75, 0.0);
+        let oslo_high: WGS84<f64> = WGS84::new_deg(59.95, 10.75, 100.0);
 
-        let stockholm: WGS84<f64> = WGS84::new(59.329444, 18.068611, 0.0);
-        let stockholm_high: WGS84<f64> = WGS84::new(59.329444, 18.068611, 100.0);
+        let stockholm: WGS84<f64> = WGS84::new_deg(59.329444, 18.068611, 0.0);
+        let stockholm_high: WGS84<f64> = WGS84::new_deg(59.329444, 18.068611, 100.0);
 
         for &(place, place_high) in [(oslo, oslo_high), (stockholm, stockholm_high)].iter() {
             let distance =


### PR DESCRIPTION
* Consistent naming scheme: Instead of having the constructor with no suffix using degrees, but the getter with no suffix using radians, use `_deg()` and `_rad()` suffixes to disambiguate.
* Add radians constructors for WGS84. This is useful for cases where the latitude and longitude are already present in radians.
* Bump version number from 0.4.4 to 0.5.0 because of the breaking renaming change.