### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nav-types"
-version = "0.5.1"
+version = "0.5.2"
 authors = ["Jørgen Nordmoen <nordmoen90@gmail.com>"]
 description = "Easily work with global positions and vectors"
 edition = "2018"
@@ -13,14 +13,14 @@ keywords = ["nav", "navigation", "ecef", "latitude", "wgs84"]
 license = "MIT"
 
 [dependencies]
-nalgebra = "0.22"
-serde = { version = "1.0.116", optional = true, features = ["serde_derive"] }
+nalgebra = "0.32"
+serde = { version = "1.0.164", optional = true, features = ["serde_derive"] }
 
 [dev-dependencies]
 assert = "0.7"
 quickcheck = "0.9.2"
 rand = "0.7.3"
-serde_test = "1.0.116"
+serde_test = "1.0.164"
 
 
 [features]

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ have meaning as geographic entities.
 Place this in your `Cargo.toml`
 
 ```toml
-nav-types = "0.5.1"
+nav-types = "0.5.2"
 ```
 
 and use it to calculate vectors and position:

--- a/src/ecef.rs
+++ b/src/ecef.rs
@@ -1,8 +1,9 @@
 use crate::enu::ENU;
 use crate::nvector::NVector;
+use crate::utils::RealFieldCopy;
 use crate::wgs84::{ECCENTRICITY_SQ, SEMI_MAJOR_AXIS, SEMI_MINOR_AXIS, WGS84};
 use crate::Access;
-use na::{Matrix3, Point3, RealField};
+use na::{Matrix3, Point3};
 use std::convert::{From, Into};
 use std::ops::{Add, AddAssign, Sub, SubAssign};
 
@@ -11,16 +12,16 @@ use std::ops::{Add, AddAssign, Sub, SubAssign};
 /// This struct represents a position in the ECEF coordinate system.
 /// See: [ECEF](https://en.wikipedia.org/wiki/ECEF) for general description.
 #[derive(Debug, Copy, Clone, PartialEq)]
-pub struct ECEF<N: RealField>(Point3<N>);
+pub struct ECEF<N: RealFieldCopy>(Point3<N>);
 
-impl<N: RealField> ECEF<N> {
+impl<N: RealFieldCopy> ECEF<N> {
     /// Create a new ECEF position
     pub fn new(x: N, y: N, z: N) -> ECEF<N> {
         ECEF(Point3::new(x, y, z))
     }
 }
 
-impl<N: RealField> ECEF<N> {
+impl<N: RealFieldCopy> ECEF<N> {
     /// Get the X component of this position
     pub fn x(&self) -> N {
         self.0.x
@@ -37,7 +38,7 @@ impl<N: RealField> ECEF<N> {
     }
 }
 
-impl<N: RealField> ECEF<N> {
+impl<N: RealFieldCopy> ECEF<N> {
     /// Create a rotation matrix from ECEF frame to ENU frame
     fn r_enu_from_ecef(self) -> Matrix3<N> {
         let wgs = WGS84::from(self);
@@ -62,7 +63,7 @@ impl<N: RealField> ECEF<N> {
     /// Euclidean distance between two ECEF positions
     pub fn distance(&self, other: &ECEF<N>) -> N
     where
-        N: RealField,
+        N: RealFieldCopy,
     {
         (other.0 - self.0).norm()
     }
@@ -70,7 +71,7 @@ impl<N: RealField> ECEF<N> {
 
 impl<N, T> Add<T> for ECEF<N>
 where
-    N: RealField,
+    N: RealFieldCopy,
     T: Into<ENU<N>>,
 {
     type Output = ECEF<N>;
@@ -83,7 +84,7 @@ where
 
 impl<N, T> AddAssign<T> for ECEF<N>
 where
-    N: RealField + AddAssign,
+    N: RealFieldCopy + AddAssign,
     T: Into<ENU<N>>,
 {
     fn add_assign(&mut self, right: T) {
@@ -92,7 +93,7 @@ where
     }
 }
 
-impl<N: RealField> Sub<ECEF<N>> for ECEF<N> {
+impl<N: RealFieldCopy> Sub<ECEF<N>> for ECEF<N> {
     type Output = ENU<N>;
     fn sub(self, right: ECEF<N>) -> ENU<N> {
         let enu = right.r_enu_from_ecef() * (self.0 - right.0);
@@ -102,7 +103,7 @@ impl<N: RealField> Sub<ECEF<N>> for ECEF<N> {
 
 impl<N, T> Sub<T> for ECEF<N>
 where
-    N: RealField,
+    N: RealFieldCopy,
     T: Into<ENU<N>>,
 {
     type Output = ECEF<N>;
@@ -114,7 +115,7 @@ where
 
 impl<N, T> SubAssign<T> for ECEF<N>
 where
-    N: RealField + SubAssign,
+    N: RealFieldCopy + SubAssign,
     T: Into<ENU<N>>,
 {
     fn sub_assign(&mut self, right: T) {
@@ -129,7 +130,7 @@ macro_rules! ecef_impl {
     ($T:ident) => {
         impl<N, T> Add<T> for $T<N>
         where
-            N: RealField,
+            N: RealFieldCopy,
             T: Into<ENU<N>>,
         {
             type Output = $T<N>;
@@ -140,7 +141,7 @@ macro_rules! ecef_impl {
 
         impl<N, T> AddAssign<T> for $T<N>
         where
-            N: RealField + AddAssign,
+            N: RealFieldCopy + AddAssign,
             T: Into<ENU<N>>,
         {
             fn add_assign(&mut self, right: T) {
@@ -150,7 +151,7 @@ macro_rules! ecef_impl {
 
         impl<N, T> Sub<T> for $T<N>
         where
-            N: RealField,
+            N: RealFieldCopy,
             T: Into<ENU<N>>,
         {
             type Output = $T<N>;
@@ -159,7 +160,7 @@ macro_rules! ecef_impl {
             }
         }
 
-        impl<N: RealField> Sub<$T<N>> for $T<N> {
+        impl<N: RealFieldCopy> Sub<$T<N>> for $T<N> {
             type Output = ENU<N>;
             fn sub(self, right: $T<N>) -> ENU<N> {
                 ECEF::from(self) - ECEF::from(right)
@@ -168,7 +169,7 @@ macro_rules! ecef_impl {
 
         impl<N, T> SubAssign<T> for $T<N>
         where
-            N: RealField + SubAssign,
+            N: RealFieldCopy + SubAssign,
             T: Into<ENU<N>>,
         {
             fn sub_assign(&mut self, right: T) {
@@ -184,7 +185,7 @@ ecef_impl!(NVector);
 // The only way to work with Latitude/Longitude is to convert to ECEF
 ecef_impl!(WGS84);
 
-impl<N: RealField> From<WGS84<N>> for ECEF<N> {
+impl<N: RealFieldCopy> From<WGS84<N>> for ECEF<N> {
     fn from(wgs: WGS84<N>) -> ECEF<N> {
         // Conversion from:
         // https://doi.org/10.1007/s00190-004-0375-4
@@ -205,7 +206,7 @@ impl<N: RealField> From<WGS84<N>> for ECEF<N> {
     }
 }
 
-impl<N: RealField> From<NVector<N>> for ECEF<N> {
+impl<N: RealFieldCopy> From<NVector<N>> for ECEF<N> {
     fn from(f: NVector<N>) -> ECEF<N> {
         // Constants used for calculation
         let x = f.vector().z;

--- a/src/enu.rs
+++ b/src/enu.rs
@@ -1,5 +1,6 @@
+use crate::utils::RealFieldCopy;
 use crate::Access;
-use na::{RealField, Vector3};
+use na::Vector3;
 use std::convert::Into;
 use std::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Sub, SubAssign};
 
@@ -14,9 +15,9 @@ use std::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Sub, SubAssign};
 /// can be converted to ENU with a `From` implementation will automatically
 /// be able to work with ENU at the cost of the `Into` conversion.
 #[derive(Debug, Copy, Clone, PartialEq)]
-pub struct ENU<N: RealField>(Vector3<N>);
+pub struct ENU<N: RealFieldCopy>(Vector3<N>);
 
-impl<N: RealField> ENU<N> {
+impl<N: RealFieldCopy> ENU<N> {
     /// Create a new ENU vector
     pub fn new(e: N, n: N, u: N) -> ENU<N> {
         ENU(Vector3::new(e, n, u))
@@ -28,7 +29,7 @@ impl<N: RealField> ENU<N> {
     }
 }
 
-impl<N: RealField + Copy> ENU<N> {
+impl<N: RealFieldCopy> ENU<N> {
     /// Get the East component of this vector
     pub fn east(&self) -> N {
         self.0.x
@@ -45,59 +46,59 @@ impl<N: RealField + Copy> ENU<N> {
     }
 }
 
-impl<N: RealField + Copy + Add<N, Output = N>, T: Into<ENU<N>>> Add<T> for ENU<N> {
+impl<N: RealFieldCopy + Add<N, Output = N>, T: Into<ENU<N>>> Add<T> for ENU<N> {
     type Output = ENU<N>;
     fn add(self, right: T) -> Self::Output {
         ENU(self.0 + right.into().0)
     }
 }
 
-impl<N: RealField + Copy + AddAssign<N>, T: Into<ENU<N>>> AddAssign<T> for ENU<N> {
+impl<N: RealFieldCopy + AddAssign<N>, T: Into<ENU<N>>> AddAssign<T> for ENU<N> {
     fn add_assign(&mut self, right: T) {
         self.0 += right.into().0
     }
 }
 
-impl<N: RealField + Copy + Sub<N, Output = N>, T: Into<ENU<N>>> Sub<T> for ENU<N> {
+impl<N: RealFieldCopy + Sub<N, Output = N>, T: Into<ENU<N>>> Sub<T> for ENU<N> {
     type Output = ENU<N>;
     fn sub(self, right: T) -> Self::Output {
         ENU(self.0 - right.into().0)
     }
 }
 
-impl<N: RealField + Copy + SubAssign<N>, T: Into<ENU<N>>> SubAssign<T> for ENU<N> {
+impl<N: RealFieldCopy + SubAssign<N>, T: Into<ENU<N>>> SubAssign<T> for ENU<N> {
     fn sub_assign(&mut self, right: T) {
         self.0 -= right.into().0
     }
 }
 
-impl<N: RealField + Copy + Mul<N, Output = N>> Mul<N> for ENU<N> {
+impl<N: RealFieldCopy + Mul<N, Output = N>> Mul<N> for ENU<N> {
     type Output = ENU<N>;
     fn mul(self, right: N) -> Self::Output {
         ENU(self.0 * right)
     }
 }
 
-impl<N: RealField + Copy + MulAssign<N>> MulAssign<N> for ENU<N> {
+impl<N: RealFieldCopy + MulAssign<N>> MulAssign<N> for ENU<N> {
     fn mul_assign(&mut self, right: N) {
         self.0 *= right
     }
 }
 
-impl<N: RealField + Copy + Div<N, Output = N>> Div<N> for ENU<N> {
+impl<N: RealFieldCopy + Div<N, Output = N>> Div<N> for ENU<N> {
     type Output = ENU<N>;
     fn div(self, right: N) -> Self::Output {
         ENU(self.0 / right)
     }
 }
 
-impl<N: RealField + Copy + DivAssign<N>> DivAssign<N> for ENU<N> {
+impl<N: RealFieldCopy + DivAssign<N>> DivAssign<N> for ENU<N> {
     fn div_assign(&mut self, right: N) {
         self.0 /= right
     }
 }
 
-impl<N: RealField> Access<Vector3<N>> for ENU<N> {
+impl<N: RealFieldCopy> Access<Vector3<N>> for ENU<N> {
     fn access(self) -> Vector3<N> {
         self.0
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,6 +50,7 @@ mod ecef;
 mod enu;
 mod ned;
 mod nvector;
+mod utils;
 mod wgs84;
 
 pub use self::ecef::ECEF;

--- a/src/ned.rs
+++ b/src/ned.rs
@@ -1,6 +1,7 @@
 use crate::enu::ENU;
+use crate::utils::RealFieldCopy;
 use crate::Access;
-use na::{RealField, Vector3};
+use na::Vector3;
 use std::convert::From;
 use std::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
@@ -10,9 +11,9 @@ use std::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssi
 /// See: [NED](https://en.wikipedia.org/wiki/North_east_down) for a general
 /// description.
 #[derive(Debug, Copy, Clone, PartialEq)]
-pub struct NED<N: RealField>(Vector3<N>);
+pub struct NED<N: RealFieldCopy>(Vector3<N>);
 
-impl<N: RealField> NED<N> {
+impl<N: RealFieldCopy> NED<N> {
     /// Create a new NED vector
     pub fn new(n: N, e: N, d: N) -> NED<N> {
         NED(Vector3::new(n, e, d))
@@ -24,7 +25,7 @@ impl<N: RealField> NED<N> {
     }
 }
 
-impl<N: RealField + Copy> NED<N> {
+impl<N: RealFieldCopy> NED<N> {
     /// Get the North component of this vector
     pub fn north(&self) -> N {
         self.0.x
@@ -41,66 +42,66 @@ impl<N: RealField + Copy> NED<N> {
     }
 }
 
-impl<N: RealField + Copy + Neg<Output = N>> From<NED<N>> for ENU<N> {
+impl<N: RealFieldCopy + Neg<Output = N>> From<NED<N>> for ENU<N> {
     /// Convert `NED` vectors into `ENU`
     fn from(e: NED<N>) -> Self {
         ENU::new(e.east(), e.north(), -e.down())
     }
 }
 
-impl<N: RealField + Copy + Add<N, Output = N>> Add<NED<N>> for NED<N> {
+impl<N: RealFieldCopy + Add<N, Output = N>> Add<NED<N>> for NED<N> {
     type Output = NED<N>;
     fn add(self, right: NED<N>) -> NED<N> {
         NED(self.0 + right.0)
     }
 }
 
-impl<N: RealField + Copy + AddAssign<N>> AddAssign<NED<N>> for NED<N> {
+impl<N: RealFieldCopy + AddAssign<N>> AddAssign<NED<N>> for NED<N> {
     fn add_assign(&mut self, right: NED<N>) {
         self.0 += right.0
     }
 }
 
-impl<N: RealField + Copy + Sub<N, Output = N>> Sub<NED<N>> for NED<N> {
+impl<N: RealFieldCopy + Sub<N, Output = N>> Sub<NED<N>> for NED<N> {
     type Output = NED<N>;
     fn sub(self, right: NED<N>) -> NED<N> {
         NED(self.0 - right.0)
     }
 }
 
-impl<N: RealField + Copy + SubAssign<N>> SubAssign<NED<N>> for NED<N> {
+impl<N: RealFieldCopy + SubAssign<N>> SubAssign<NED<N>> for NED<N> {
     fn sub_assign(&mut self, right: NED<N>) {
         self.0 -= right.0
     }
 }
 
-impl<N: RealField + Copy + Mul<N, Output = N>> Mul<N> for NED<N> {
+impl<N: RealFieldCopy + Mul<N, Output = N>> Mul<N> for NED<N> {
     type Output = NED<N>;
     fn mul(self, right: N) -> NED<N> {
         NED(self.0 * right)
     }
 }
 
-impl<N: RealField + Copy + MulAssign<N>> MulAssign<N> for NED<N> {
+impl<N: RealFieldCopy + MulAssign<N>> MulAssign<N> for NED<N> {
     fn mul_assign(&mut self, right: N) {
         self.0 *= right
     }
 }
 
-impl<N: RealField + Copy + Div<N, Output = N>> Div<N> for NED<N> {
+impl<N: RealFieldCopy + Div<N, Output = N>> Div<N> for NED<N> {
     type Output = NED<N>;
     fn div(self, right: N) -> NED<N> {
         NED(self.0 / right)
     }
 }
 
-impl<N: RealField + Copy + DivAssign<N>> DivAssign<N> for NED<N> {
+impl<N: RealFieldCopy + DivAssign<N>> DivAssign<N> for NED<N> {
     fn div_assign(&mut self, right: N) {
         self.0 /= right
     }
 }
 
-impl<N: RealField> Access<Vector3<N>> for NED<N> {
+impl<N: RealFieldCopy> Access<Vector3<N>> for NED<N> {
     fn access(self) -> Vector3<N> {
         self.0
     }

--- a/src/nvector.rs
+++ b/src/nvector.rs
@@ -1,6 +1,7 @@
 use crate::ecef::ECEF;
+use crate::utils::RealFieldCopy;
 use crate::wgs84::{ECCENTRICITY_SQ, SEMI_MAJOR_AXIS, WGS84};
-use na::{RealField, Vector3};
+use na::Vector3;
 use std::convert::From;
 
 /// N-Vector position
@@ -10,19 +11,19 @@ use std::convert::From;
 /// the poles compared to WGS84 Latitude, Longitude format.
 /// See: [nvector](http://www.navlab.net/nvector/) for detailed information.
 #[derive(PartialEq, Clone, Copy, Debug)]
-pub struct NVector<N: RealField> {
+pub struct NVector<N: RealFieldCopy> {
     vec: Vector3<N>,
     alt: N,
 }
 
-impl<N: RealField> NVector<N> {
+impl<N: RealFieldCopy> NVector<N> {
     /// Create a new NVector
     pub fn new(vec: Vector3<N>, altitude: N) -> NVector<N> {
         NVector { vec, alt: altitude }
     }
 }
 
-impl<N: RealField + Copy> NVector<N> {
+impl<N: RealFieldCopy> NVector<N> {
     /// Get the vector component of this position
     pub fn vector(&self) -> Vector3<N> {
         self.vec
@@ -34,7 +35,7 @@ impl<N: RealField + Copy> NVector<N> {
     }
 }
 
-impl<N: RealField> From<WGS84<N>> for NVector<N> {
+impl<N: RealFieldCopy> From<WGS84<N>> for NVector<N> {
     fn from(f: WGS84<N>) -> NVector<N> {
         // This implementation defines the ECEF coordinate system to have the Z
         // axes point directly north, this affects the way which N-vectors are
@@ -49,7 +50,7 @@ impl<N: RealField> From<WGS84<N>> for NVector<N> {
     }
 }
 
-impl<N: RealField> From<ECEF<N>> for NVector<N> {
+impl<N: RealFieldCopy> From<ECEF<N>> for NVector<N> {
     #![allow(clippy::many_single_char_names)]
     fn from(ecef: ECEF<N>) -> NVector<N> {
         // These are often used constants below:

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,5 @@
+use na::RealField;
+
+/// Trait that combined RealField and Copy. Necessary to preserve simba v0.5.1 behavior
+pub trait RealFieldCopy: RealField + Copy {}
+impl<N: RealField + Copy> RealFieldCopy for N {}

--- a/src/wgs84.rs
+++ b/src/wgs84.rs
@@ -1,6 +1,6 @@
 use crate::ecef::ECEF;
 use crate::nvector::NVector;
-use na::RealField;
+use crate::utils::RealFieldCopy;
 use std::convert::From;
 
 #[cfg(test)]
@@ -44,7 +44,7 @@ pub struct WGS84<N> {
     alt: N,
 }
 
-impl<N: RealField> WGS84<N>
+impl<N: RealFieldCopy> WGS84<N>
 where
     f64: From<N>,
 {
@@ -193,7 +193,7 @@ impl<N: Copy> WGS84<N> {
     }
 }
 
-impl<N: RealField> From<NVector<N>> for WGS84<N> {
+impl<N: RealFieldCopy> From<NVector<N>> for WGS84<N> {
     fn from(f: NVector<N>) -> WGS84<N> {
         // This implementation defines the ECEF coordinate system to have the Z
         // axes point directly north, this affects the way which N-vectors are
@@ -218,7 +218,7 @@ impl<N: RealField> From<NVector<N>> for WGS84<N> {
     }
 }
 
-impl<N: RealField> From<ECEF<N>> for WGS84<N> {
+impl<N: RealFieldCopy> From<ECEF<N>> for WGS84<N> {
     #![allow(clippy::many_single_char_names)]
     fn from(ecef: ECEF<N>) -> WGS84<N> {
         // https://en.wikipedia.org/wiki/Geographic_coordinate_conversion#The_application_of_Ferrari's_solution


### PR DESCRIPTION
Hello! On a recent dependabot run, I noticed that nalgebra <0.27.1 has a critical vulnerability. This PR updates the versions of serde and nalgebra to the latest, and changes the RealField trait to RealFieldCopy to mimic simba v0.5.1 behavior to make the crate build. I did look into updating quickcheck and rand, but it turned out to break the tests in a way where it wasn't clear whether the code or the test had the issue.