### PR TITLE
Making RealFieldCopy accessible outside the crate.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,7 @@ mod nvector;
 mod utils;
 mod wgs84;
 
+pub use self::utils::RealFieldCopy;
 pub use self::ecef::ECEF;
 pub use self::enu::ENU;
 pub use self::ned::NED;


### PR DESCRIPTION
This allows code using this crate to write templated code against the types within this crate without directly importing the same version of nalgebra, and can prevent such code from breaking whenever this crate's version of nalgebra is updated.