### PR TITLE
Add const support

### DIFF
--- a/src/ecef.rs
+++ b/src/ecef.rs
@@ -16,7 +16,7 @@ pub struct ECEF<N: RealFieldCopy>(Point3<N>);
 
 impl<N: RealFieldCopy> ECEF<N> {
     /// Create a new ECEF position
-    pub fn new(x: N, y: N, z: N) -> ECEF<N> {
+    pub const fn new(x: N, y: N, z: N) -> ECEF<N> {
         ECEF(Point3::new(x, y, z))
     }
 }
@@ -242,6 +242,12 @@ mod tests {
         close(a.x(), b.x(), 0.000001);
         close(a.y(), b.y(), 0.000001);
         close(a.z(), b.z(), 0.000001);
+    }
+
+    #[test]
+    fn const_ecef_construction() {
+        const OSLO: ECEF<f64> = ECEF::new(3145735.0, 597236.0, 5497690.0);
+        let _ = OSLO;
     }
 
     quickcheck! {

--- a/src/enu.rs
+++ b/src/enu.rs
@@ -20,7 +20,7 @@ pub struct ENU<N: RealFieldCopy>(Vector3<N>);
 
 impl<N: RealFieldCopy> ENU<N> {
     /// Create a new ENU vector
-    pub fn new(e: N, n: N, u: N) -> ENU<N> {
+    pub const fn new(e: N, n: N, u: N) -> ENU<N> {
         ENU(Vector3::new(e, n, u))
     }
 
@@ -117,6 +117,12 @@ impl<N: RealFieldCopy> Access<Vector3<N>> for ENU<N> {
 mod tests {
     use super::*;
     use crate::ned::NED;
+
+    #[test]
+    fn const_enu_construction() {
+        const VEC: ENU<f64> = ENU::new(1.0, 2.0, 3.0);
+        let _ = VEC;
+    }
 
     quickcheck! {
         fn create_enu(e: f32, n: f32, u: f32) -> () {

--- a/src/ned.rs
+++ b/src/ned.rs
@@ -15,7 +15,7 @@ pub struct NED<N: RealFieldCopy>(Vector3<N>);
 
 impl<N: RealFieldCopy> NED<N> {
     /// Create a new NED vector
-    pub fn new(n: N, e: N, d: N) -> NED<N> {
+    pub const fn new(n: N, e: N, d: N) -> NED<N> {
         NED(Vector3::new(n, e, d))
     }
 
@@ -111,6 +111,12 @@ impl<N: RealFieldCopy> Access<Vector3<N>> for NED<N> {
 mod tests {
     use super::*;
     use crate::enu::ENU;
+
+    #[test]
+    fn const_ned_construction() {
+        const VEC: NED<f64> = NED::new(1.0, 2.0, 3.0);
+        let _ = VEC;
+    }
 
     quickcheck! {
         fn create_ned(n: f32, e: f32, d: f32) -> () {

--- a/src/nvector.rs
+++ b/src/nvector.rs
@@ -18,19 +18,19 @@ pub struct NVector<N: RealFieldCopy> {
 
 impl<N: RealFieldCopy> NVector<N> {
     /// Create a new NVector
-    pub fn new(vec: Vector3<N>, altitude: N) -> NVector<N> {
+    pub const fn new(vec: Vector3<N>, altitude: N) -> NVector<N> {
         NVector { vec, alt: altitude }
     }
 }
 
 impl<N: RealFieldCopy> NVector<N> {
     /// Get the vector component of this position
-    pub fn vector(&self) -> Vector3<N> {
+    pub const fn vector(&self) -> Vector3<N> {
         self.vec
     }
 
     /// Get the altitude of this position
-    pub fn altitude(&self) -> N {
+    pub const fn altitude(&self) -> N {
         self.alt
     }
 }
@@ -93,6 +93,14 @@ mod tests {
     use crate::ecef::ECEF;
     use crate::wgs84::WGS84;
     use assert::close;
+
+    #[test]
+    fn const_nvector_construction() {
+        const POS: NVector<f64> = NVector::new(Vector3::new(1.0, 2.0, 3.0), 4.0);
+        const ALT: f64 = POS.altitude();
+        const VEC: Vector3<f64> = POS.vector();
+        let _ = (POS, ALT, VEC);
+    }
 
     quickcheck! {
         fn from_wgs84(wgs: WGS84<f64>) -> () {

--- a/src/wgs84.rs
+++ b/src/wgs84.rs
@@ -178,17 +178,138 @@ where
     }
 }
 
+macro_rules! impl_const_wgs84 {
+    ($ty:ty, $pi:path, $half_pi:path) => {
+        impl WGS84<$ty> {
+            /// Create a new WGS84 position
+            ///
+            /// # Arguments
+            /// - `latitude` in degrees
+            /// - `longitude` in degrees
+            /// - `altitude` in meters
+            ///
+            /// # Panics
+            /// This will panic if `latitude` or `longitude` are not defined on the
+            /// WGS84 ellipsoid.
+            pub const fn const_from_degrees_and_meters(
+                latitude: $ty,
+                longitude: $ty,
+                altitude: $ty,
+            ) -> WGS84<$ty> {
+                assert!(
+                    latitude >= -90.0 && latitude <= 90.0,
+                    "Latitude must be in the range [-90, 90]"
+                );
+                assert!(
+                    longitude >= -180.0 && longitude <= 180.0,
+                    "Longitude must be in the range [-180, 180]"
+                );
+                WGS84 {
+                    lat: latitude * ($pi / 180.0),
+                    lon: longitude * ($pi / 180.0),
+                    alt: altitude,
+                }
+            }
+
+            /// Try to create a new WGS84 position
+            ///
+            /// # Arguments
+            /// - `latitude` in degrees
+            /// - `longitude` in degrees
+            /// - `altitude` in meters
+            pub const fn const_try_from_degrees_and_meters(
+                latitude: $ty,
+                longitude: $ty,
+                altitude: $ty,
+            ) -> Option<WGS84<$ty>> {
+                if latitude >= -90.0
+                    && latitude <= 90.0
+                    && longitude >= -180.0
+                    && longitude <= 180.0
+                {
+                    Some(WGS84 {
+                        lat: latitude * ($pi / 180.0),
+                        lon: longitude * ($pi / 180.0),
+                        alt: altitude,
+                    })
+                } else {
+                    None
+                }
+            }
+
+            /// Create a new WGS84 position
+            ///
+            /// # Arguments
+            /// - `latitude` in radians
+            /// - `longitude` in radians
+            /// - `altitude` in meters
+            ///
+            /// # Panics
+            /// This will panic if `latitude` or `longitude` are not defined on the
+            /// WGS84 ellipsoid.
+            pub const fn const_from_radians_and_meters(
+                latitude: $ty,
+                longitude: $ty,
+                altitude: $ty,
+            ) -> WGS84<$ty> {
+                assert!(
+                    latitude >= -$half_pi && latitude <= $half_pi,
+                    "Latitude must be in the range [-π/2, π/2]"
+                );
+                assert!(
+                    longitude >= -$pi && longitude <= $pi,
+                    "Longitude must be in the range [-π, π]"
+                );
+                WGS84 {
+                    lat: latitude,
+                    lon: longitude,
+                    alt: altitude,
+                }
+            }
+
+            /// Try to create a new WGS84 position
+            ///
+            /// # Arguments
+            /// - `latitude` in radians
+            /// - `longitude` in radians
+            /// - `altitude` in meters
+            pub const fn const_try_from_radians_and_meters(
+                latitude: $ty,
+                longitude: $ty,
+                altitude: $ty,
+            ) -> Option<WGS84<$ty>> {
+                if latitude >= -$half_pi
+                    && latitude <= $half_pi
+                    && longitude >= -$pi
+                    && longitude <= $pi
+                {
+                    Some(WGS84 {
+                        lat: latitude,
+                        lon: longitude,
+                        alt: altitude,
+                    })
+                } else {
+                    None
+                }
+            }
+        }
+    };
+}
+
+impl_const_wgs84!(f32, core::f32::consts::PI, core::f32::consts::FRAC_PI_2);
+impl_const_wgs84!(f64, core::f64::consts::PI, core::f64::consts::FRAC_PI_2);
+
 impl<N: Copy> WGS84<N> {
     /// Get altitude of position, in meters
-    pub fn altitude(&self) -> N {
+    pub const fn altitude(&self) -> N {
         self.alt
     }
     /// Get latitude of position, in radians
-    pub fn latitude_radians(&self) -> N {
+    pub const fn latitude_radians(&self) -> N {
         self.lat
     }
     /// Get longitude of position, in radians
-    pub fn longitude_radians(&self) -> N {
+    pub const fn longitude_radians(&self) -> N {
         self.lon
     }
 }
@@ -343,6 +464,19 @@ mod tests {
     #[test]
     fn test_create_wgs84() {
         quickcheck(create_wgs84 as fn(f32, f32, f32) -> TestResult);
+    }
+
+    #[test]
+    fn const_wgs84_construction() {
+        const OSLO: WGS84<f64> = WGS84::<f64>::const_from_degrees_and_meters(59.95, 10.75, 0.0);
+        const OSLO_ALT: f64 = OSLO.altitude();
+        const ORIGIN: WGS84<f64> = WGS84::<f64>::const_from_radians_and_meters(0.0, 0.0, 0.0);
+        const ORIGIN_LAT: f64 = ORIGIN.latitude_radians();
+        const VALID: Option<WGS84<f64>> =
+            WGS84::<f64>::const_try_from_radians_and_meters(0.1, 0.2, 12.3);
+        const INVALID: Option<WGS84<f64>> =
+            WGS84::<f64>::const_try_from_degrees_and_meters(100.0, 0.0, 0.0);
+        let _ = (OSLO, OSLO_ALT, ORIGIN, ORIGIN_LAT, VALID, INVALID);
     }
 
     #[test]


### PR DESCRIPTION
- Marks functions const where it makes sense.
- Add separate const constructors to WGS84 for f32/f64, since the existing generic constructors rely on non-const trait methods.