### PR TITLE
Chore: update nalgebra dependency from 0.32 to 0.34.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["nav", "navigation", "ecef", "latitude", "wgs84"]
 license = "MIT"
 
 [dependencies]
-nalgebra = { version = "0.32", default-features = false }
+nalgebra = { version = "0.34.1", default-features = false }
 serde = { version = "1.0.164", default-features = false, optional = true, features = ["serde_derive"] }
 
 [dev-dependencies]

--- a/src/ecef.rs
+++ b/src/ecef.rs
@@ -281,7 +281,7 @@ mod tests {
             let vec_e2 = r_ecef_from_enu * vec_enu.access();
 
             // These should be equivalent:
-            close(vec_e.as_ref(), vec_e2.as_ref(), 0.0000001);
+            close(vec_e.as_ref() as &[f64], vec_e2.as_ref() as &[f64], 0.0000001);
         }
 
         fn add_vector(a: WGS84<f64>, b: WGS84<f64>) -> () {
@@ -336,7 +336,7 @@ mod tests {
 
             let ecef_2 = ecef + enu;
             let enu_2 = ecef_2 - ecef;
-            close(enu.access().as_ref(), enu_2.access().as_ref(), 0.0000001);
+            close(enu.access().as_ref() as &[f64], enu_2.access().as_ref() as &[f64], 0.0000001);
         }
     }
 }

--- a/src/nvector.rs
+++ b/src/nvector.rs
@@ -116,7 +116,7 @@ mod tests {
             let test = NVector::from(ECEF::from(wgs));
 
             close(ans.altitude(), test.altitude(), 0.000001);
-            close(ans.vector().as_ref(), test.vector().as_ref(), 0.000001)
+            close(ans.vector().as_ref() as &[f64], test.vector().as_ref() as &[f64], 0.000001)
         }
     }
 }


### PR DESCRIPTION
Hi,
I updated the `nalgebra` dependency from version `0.32` to version `0.34.1`, this reduces dependency conflicts with other crates that already moved to a new `nalgebra` version. 

### Changes done
- Bumped `nalgebra` version in `Cargo.toml` from `0.32` to `0.34.1`
- Fixed `AsRef` ambiguity in tests caused by a new impl added in nalgebra `0.34.1`:
  `impl AsRef<[T; 3]> for Matrix<T, Const<3>, Const<1>, S>` now conflicts with
  `impl AsRef<[T]> for Matrix<T, R, C, S>`, requiring explicit type annotations
  (`as &[f64]`) in test helpers

### Testing
- 1 test (`test wgs84::tests::test_ser_de`) is ignored (pre-existing and not related to this change)
- All other existing tests pass with the updated dependency
